### PR TITLE
Create apache-license-v2.md

### DIFF
--- a/apache-license-v2.md
+++ b/apache-license-v2.md
@@ -1,0 +1,13 @@
+Copyright 2019 QlikTech International AB
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.


### PR DESCRIPTION
After legal approval, we may use the Apache License v2 in projects as well. Adding template.